### PR TITLE
Pass `FunnyLoader` String To Launchers

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -110,7 +110,7 @@ function updateCursor()
     if playdate.buttonJustReleased(playdate.kButtonA) then
         if launchers[selected] then
             print("FOUND OS PDX \""..launchers[selected]..",\" LAUNCHING.")
-            playdate.system.switchToGame("/System/Launchers/"..launchers[selected])  
+            playdate.system.switchToGame("/System/Launchers/"..launchers[selected], "FunnyLoader")  
         else
             print("NO LAUNCHERS TO LAUNCH.")    
         end  
@@ -136,7 +136,7 @@ function boot()
         else
             if fle.exists("/System/Launchers/"..config["default"]) then
                 print("FOUND DEFAULT OS PDX \""..config["default"]..",\" LAUNCHING.")
-                playdate.system.switchToGame("/System/Launchers/"..config["default"])
+                playdate.system.switchToGame("/System/Launchers/"..config["default"], "FunnyLoader")
                 return
             else
                 print("INVALID DEFAULT OS PDX \""..config["default"]..",\" RESETTING DEFAULT VALUE.")    


### PR DESCRIPTION
When booting launchers pass in a `FunnyLoader` string as an addition argument to `playdate.system.switchToGame` which shows up as a value in `playdate.argv` allowing launchers to detect when they have been booted with FunnyLoader. This could be used to allow showing FunnyLoader in the games list to boot into other launchers.